### PR TITLE
Fix main() function conflicting types

### DIFF
--- a/demos/vc.c
+++ b/demos/vc.c
@@ -65,7 +65,7 @@ bool resize_texture(SDL_Renderer *renderer, size_t new_width, size_t new_height)
     return true;
 }
 
-int main(void)
+int main(int argc, char **args)
 {
     int result = 0;
 


### PR DESCRIPTION
Fixes GCC error for main() function conflicting with SDL_main() function.