### PR TITLE
Add SDL2 checker in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,22 @@ mkdir -p ./build/assets/
 ./build/png2c ./assets/tsodinPog.png > ./build/assets/tsodinPog.c
 
 # Build VC demos
+# Check if SDL2 has been installed
+if ! [ -x "$(which sdl2-config)" ];then
+	set +x
+	echo "You have not installed SDL2"
+	echo "Checking 'https://wiki.libsdl.org/Installation' to install SDL2"
+	echo "Or quick look the installation guide from libsdl:"
+	echo "$ git clone https://github.com/libsdl-org/SDL"
+	echo "$ cd SDL"
+	echo "$ mkdir build"
+	echo "$ cd build"
+	echo "$ ../configure"
+	echo "$ make"
+	echo "$ sudo make install"
+	exit 1
+fi
+
 build_vc_demo triangle &
 build_vc_demo 3d &
 build_vc_demo squish &


### PR DESCRIPTION
Hi,thanks for your amazing job.
when i compile locally with `build.sh`,i got some errors about missing dependency of SDL2. 
![image](https://user-images.githubusercontent.com/13912755/191644816-d94ffc61-ec14-4572-91cc-08134a5d88ae.png)
So i continue to install SDL2 to complete the building of this project.
I also add some checker and help info into build.sh, want to give some bros 'Hint' but not 'Error'.
Please help me if i am doing it incorrectly.
Thanks again.