### PR TITLE
Make `build.sh` fail if one of the jobs fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ set -xe
 COMMON_CFLAGS="-Wall -Wextra -ggdb -I. -I./build/ -I./thirdparty/"
 
 build_vc_demo() {
+    trap '[ $? -eq 0 ] || echo __FAIL__' EXIT
+
     NAME=$1
 
     clang $COMMON_CFLAGS -Os -fno-builtin --target=wasm32 --no-standard-libraries -Wl,--no-entry -Wl,--export=render -Wl,--export=__heap_base -Wl,--allow-undefined -o ./build/$NAME.wasm -DPLATFORM=WASM_PLATFORM ./demos/$NAME.c
@@ -24,8 +26,13 @@ mkdir -p ./build/assets/
 ./build/png2c ./assets/tsodinPog.png > ./build/assets/tsodinPog.c
 
 # Build VC demos
-build_vc_demo triangle &
-build_vc_demo 3d &
-build_vc_demo squish &
-build_vc_demo triangle3d &
-wait # TODO: the whole script must fail if one of the jobs fails
+RESULT=$(
+    build_vc_demo triangle &
+    build_vc_demo 3d &
+    build_vc_demo squish &
+    build_vc_demo triangle3d &
+)
+
+case "$RESULT" in
+    *__FAIL__*) exit 1 ;;
+esac


### PR DESCRIPTION
A small hack to implement a TODO from `build.sh`. AFAIK, the only other way to do it is to use temporary files, but that wouldn't be any prettier. It relies on `build_vc_demo()` not outputting anything useful to stdout (as stdout gets captured), but it works :)