### PR TITLE
Backface culling, basic lighting, terminal improvements

### DIFF
--- a/demos/model3d.c
+++ b/demos/model3d.c
@@ -61,6 +61,35 @@ static Vector3 rotate_y(Vector3 p, float delta_angle)
     return make_vector3(cosf(angle)*mag, p.y, sinf(angle)*mag);
 }
 
+static Vector3 cross(Vector3 a, Vector3 b) {
+    return make_vector3(
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x);
+}
+
+static Vector3 subtract3(Vector3 l, Vector3 r) {
+    return make_vector3(l.x - r.x, l.y - r.y, l.z - r.z);
+}
+
+static void normalize3(Vector3 *v) {
+    float mag_sqr = v->x * v->x + v->y * v->y + v->z * v->z;
+    if (mag_sqr < EPSILON*EPSILON) {
+        v->x = 0;
+        v->y = 0;
+        v->z = 0;
+        return;
+    }
+    float mag = sqrtf(mag_sqr);
+    v->x /= mag;
+    v->y /= mag;
+    v->z /= mag;
+}
+
+static float dot3(Vector3 a, Vector3 b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
 Olivec_Canvas vc_render(float dt)
 {
     angle += 0.25*PI*dt;
@@ -68,6 +97,11 @@ Olivec_Canvas vc_render(float dt)
     Olivec_Canvas oc = olivec_canvas(pixels, WIDTH, HEIGHT, WIDTH);
     olivec_fill(oc, BACKGROUND_COLOR);
     for (size_t i = 0; i < WIDTH*HEIGHT; ++i) zbuffer[i] = 0;
+
+#ifdef LIGHTING
+    Vector3 sun = make_vector3(1, 3, -2);
+    normalize3(&sun);
+#endif
 
     for (size_t i = 0; i < faces_count; ++i) {
         int a = faces[i][0];
@@ -81,6 +115,21 @@ Olivec_Canvas vc_render(float dt)
         Vector2 p2 = project_2d_scr(project_3d_2d(v2));
         Vector2 p3 = project_2d_scr(project_3d_2d(v3));
 
+#ifdef LIGHTING
+        Vector3 normal = cross(subtract3(v2, v1), subtract3(v3, v1));
+        normalize3(&normal);
+
+        float diff = (dot3(normal, sun) + 1.0f) / 2.0f;
+        int dq = (int)(diff * 255);
+#endif
+
+#ifdef BACKFACE_CULLING
+        if ((p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x) <= 0) continue;
+#endif
+#ifdef FRONTFACE_CULLING
+        if ((p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x) >= 0) continue;
+#endif
+
         int x1 = p1.x;
         int x2 = p2.x;
         int x3 = p3.x;
@@ -90,9 +139,12 @@ Olivec_Canvas vc_render(float dt)
         int lx, hx, ly, hy;
         if (olivec_normalize_triangle(oc.width, oc.height, x1, y1, x2, y2, x3, y3, &lx, &hx, &ly, &hy)) {
             for (int y = ly; y <= hy; ++y) {
+                bool has_entered = false;
+            
                 for (int x = lx; x <= hx; ++x) {
                     int u1, u2, det;
                     if (olivec_barycentric(x1, y1, x2, y2, x3, y3, x, y, &u1, &u2, &det)) {
+                        has_entered = true;
                         int u3 = det - u1 - u2;
                         float z = 1/v1.z*u1/det + 1/v2.z*u2/det + 1/v3.z*u3/det;
                         float near = 0.1f;
@@ -100,6 +152,9 @@ Olivec_Canvas vc_render(float dt)
                         if (1.0f/far < z && z < 1.0f/near && z > zbuffer[y*WIDTH + x]) {
                             zbuffer[y*WIDTH + x] = z;
                             OLIVEC_PIXEL(oc, x, y) = mix_colors3(0xFF1818FF, 0xFF18FF18, 0xFFFF1818, u1, u2, det);
+#ifdef LIGHTING
+                            olivec_blend_color(&OLIVEC_PIXEL(oc, x, y), ((255 - dq)<<(3*8)));
+#endif
 
                             z = 1.0f/z;
                             if (z >= 1.0) {
@@ -109,7 +164,7 @@ Olivec_Canvas vc_render(float dt)
                                 olivec_blend_color(&OLIVEC_PIXEL(oc, x, y), (v<<(3*8)));
                             }
                         }
-                    }
+                    } else if (has_entered) break;
                 }
             }
         }

--- a/demos/model3d.c
+++ b/demos/model3d.c
@@ -115,19 +115,19 @@ Olivec_Canvas vc_render(float dt)
         Vector2 p2 = project_2d_scr(project_3d_2d(v2));
         Vector2 p3 = project_2d_scr(project_3d_2d(v3));
 
-#ifdef LIGHTING
-        Vector3 normal = cross(subtract3(v2, v1), subtract3(v3, v1));
-        normalize3(&normal);
-
-        float diff = (dot3(normal, sun) + 1.0f) / 2.0f;
-        int dq = (int)(diff * 255);
-#endif
-
 #ifdef BACKFACE_CULLING
         if ((p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x) <= 0) continue;
 #endif
 #ifdef FRONTFACE_CULLING
         if ((p2.x - p1.x) * (p3.y - p1.y) - (p2.y - p1.y) * (p3.x - p1.x) >= 0) continue;
+#endif
+
+#ifdef LIGHTING
+        Vector3 normal = cross(subtract3(v2, v1), subtract3(v3, v1));
+        normalize3(&normal);
+
+        float diffuse = (dot3(normal, sun) + 1.0f) / 2.0f;
+        int diffuse_byte_val = (int)(diffuse * 255);
 #endif
 
         int x1 = p1.x;
@@ -153,7 +153,7 @@ Olivec_Canvas vc_render(float dt)
                             zbuffer[y*WIDTH + x] = z;
                             OLIVEC_PIXEL(oc, x, y) = mix_colors3(0xFF1818FF, 0xFF18FF18, 0xFFFF1818, u1, u2, det);
 #ifdef LIGHTING
-                            olivec_blend_color(&OLIVEC_PIXEL(oc, x, y), ((255 - dq)<<(3*8)));
+                            olivec_blend_color(&OLIVEC_PIXEL(oc, x, y), (255 - diffuse_byte_val)<<(3*8));
 #endif
 
                             z = 1.0f/z;

--- a/demos/teapot3d.c
+++ b/demos/teapot3d.c
@@ -1,3 +1,5 @@
 #include "assets/utahTeapot.c"
 #define VC_TERM_SCALE_DOWN_FACTOR 10
+#define BACKFACE_CULLING
+#define LIGHTING
 #include "model3d.c"

--- a/demos/vc.c
+++ b/demos/vc.c
@@ -541,20 +541,30 @@ static void vc_term_compress_pixels(Olivec_Canvas oc)
     }
 }
 
+void sig_handler(int signo)
+{
+  if (signo == SIGINT) {
+    printf("\033[?25h");
+    exit(0);
+  }
+}
+
 int main(void)
 {
+    signal(SIGINT, sig_handler);
+    printf("\033[?25l");
     for (;;) {
         vc_term_compress_pixels(vc_render(1.f/60.f));
-        for (size_t y = 0; y < vc_term_scaled_down_height; ++y) {
+        for (size_t y = 0; y < vc_term_scaled_down_height - 1; y = y + 2) {
             for (size_t x = 0; x < vc_term_scaled_down_width; ++x) {
                 // TODO: explore the idea of figuring out aspect ratio of the character using escape ANSI codes of the terminal and rendering the image accordingly
-                printf("\033[48;5;%dm  ", vc_term_char_canvas[y*vc_term_scaled_down_width + x]);
+                printf("\033[48;5;%dm\033[38;5;%dm%s", vc_term_char_canvas[y*vc_term_scaled_down_width + x], vc_term_char_canvas[y*vc_term_scaled_down_width + vc_term_scaled_down_width + x], "\u2584");
             }
             printf("\033[0m\n");
         }
 
         usleep(1000*1000/60);
-        printf("\033[%zuA", vc_term_scaled_down_height);
+        printf("\033[%zuA", vc_term_scaled_down_height / 2);
         printf("\033[%zuD", vc_term_scaled_down_width);
     }
     return 0;


### PR DESCRIPTION
- Backface culling (frontface also available)
- Simple dot product based lighting
- Double terminal "pixel" density by using half block character with both foreground and background colors
- Hide terminal cursor
- Early exit of row when no longer inside triangle